### PR TITLE
Add PyQt6 imports

### DIFF
--- a/src/highlight_search_results/browser.py
+++ b/src/highlight_search_results/browser.py
@@ -30,17 +30,10 @@
 # Any modifications to this file must keep this entire header intact.
 
 import unicodedata
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 from aqt.browser import Browser
-from aqt.qt import qtmajor
-
-if TYPE_CHECKING or qtmajor >= 6:
-    from PyQt6.QtGui import QKeySequence, QShortcut
-    from PyQt6.QtWidgets import QMenu
-else:
-    from PyQt5.QtGui import QKeySequence
-    from PyQt5.QtWidgets import QMenu, QShortcut
+from aqt.qt import QKeySequence, QShortcut, QMenu
 
 from .libaddon.platform import checkAnkiVersion
 

--- a/src/highlight_search_results/browser.py
+++ b/src/highlight_search_results/browser.py
@@ -30,12 +30,17 @@
 # Any modifications to this file must keep this entire header intact.
 
 import unicodedata
-from typing import List, Optional
-
-from PyQt5.QtGui import QKeySequence
-from PyQt5.QtWidgets import QMenu, QShortcut
+from typing import TYPE_CHECKING, List, Optional
 
 from aqt.browser import Browser
+from aqt.qt import qtmajor
+
+if TYPE_CHECKING or qtmajor >= 6:
+    from PyQt6.QtGui import QKeySequence, QShortcut
+    from PyQt6.QtWidgets import QMenu
+else:
+    from PyQt5.QtGui import QKeySequence
+    from PyQt5.QtWidgets import QMenu, QShortcut
 
 from .libaddon.platform import checkAnkiVersion
 

--- a/src/highlight_search_results/libaddon/config/signals.py
+++ b/src/highlight_search_results/libaddon/config/signals.py
@@ -29,7 +29,14 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
-from PyQt5.QtCore import pyqtSignal, QObject
+from typing import TYPE_CHECKING
+
+from aqt.qt import qtmajor
+
+if TYPE_CHECKING or qtmajor >= 6:
+    from PyQt6.QtCore import QObject, pyqtSignal
+else:
+    from PyQt5.QtCore import QObject, pyqtSignal
 
 
 class ConfigSignals(QObject):

--- a/src/highlight_search_results/libaddon/config/signals.py
+++ b/src/highlight_search_results/libaddon/config/signals.py
@@ -29,14 +29,7 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
-from typing import TYPE_CHECKING
-
-from aqt.qt import qtmajor
-
-if TYPE_CHECKING or qtmajor >= 6:
-    from PyQt6.QtCore import QObject, pyqtSignal
-else:
-    from PyQt5.QtCore import QObject, pyqtSignal
+from aqt.qt import QObject, pyqtSignal
 
 
 class ConfigSignals(QObject):

--- a/src/highlight_search_results/libaddon/gui/basic/widgets/qt.py
+++ b/src/highlight_search_results/libaddon/gui/basic/widgets/qt.py
@@ -34,22 +34,4 @@
 Qt imports
 """
 
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
-
-# extracted from aqt.qt:
-import sip
-
-try:
-    from PyQt5.Qt import *  # noqa: F401
-except ImportError:
-    sip.setapi('QString', 2)
-    sip.setapi('QVariant', 2)
-    sip.setapi('QUrl', 2)
-    try:
-        sip.setdestroyonexit(False)
-    except:  # noqa: E722
-        # missing in older versions
-        pass
-    from PyQt4.QtCore import *  # noqa: F401
-    from PyQt4.QtGui import *  # noqa: F401
+from aqt.qt import *  # type: ignore


### PR DESCRIPTION
fixes #21

#### Description

Added PyQt6 imports, because Anki 23.10 will have Qt5 compat disabled by default.


#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Anki Version ⁨23.10 (23823d31)⁩ running from source
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian 12
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
